### PR TITLE
Add Kodikas founder experience and featured projects

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { totalExperinceCalculate } from "@/lib/utils"
 import { motion } from "framer-motion"
 import { Code, Database, Smartphone, Brain, Zap, Target } from "lucide-react"
 
@@ -37,9 +36,8 @@ export default function About() {
   ]
 
   const stats = [
-    { number: totalExperinceCalculate("short"), label: "Years Experience", icon: Target },
+    { number: "5+", label: "Years Experience", icon: Target },
     { number: "10+", label: "Projects Completed", icon: Zap },
-    { number: "100K+", label: "Users Impacted", icon: Code },
     { number: "7", label: "Team Members Led", icon: Database },
   ]
 

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -6,6 +6,20 @@ import { Calendar, MapPin, Users, TrendingUp, Building, Award } from "lucide-rea
 export default function Experience() {
   const experiences = [
     {
+      company: "Kodikas",
+      position: "Founder & Full-Stack Developer",
+      duration: "2026 – Present",
+      location: "Remote · India",
+      color: "from-emerald-500 to-teal-500",
+      achievements: [
+        "Founded an independent software studio; designed, built, and deployed multiple production products end to end (frontend, backend, infra)",
+        "Architected and built a three-portal multi-tenant e-commerce platform solo: customer storefront, merchant portal with sales analytics, and a super-admin console with oversight of all stores",
+        "Built and launched the Kodikas studio site with in-browser tools (PDF, image, video, JSON), SEO-optimized with Next.js",
+        "Launched New Sarkari Result, a government-jobs platform for Indian job seekers",
+      ],
+      projects: ["Kodikas Partner", "Kodikas Studio", "New Sarkari Result"],
+    },
+    {
       company: "FiftyFiveTechnologies Pvt. Ltd.",
       position: "Software Developer",
       duration: "Nov 2023 – Sep 2025",
@@ -88,7 +102,7 @@ export default function Experience() {
             </span>
           </h2>
           <p className="text-xl text-slate-300 max-w-3xl mx-auto">
-            4.5+ years of building innovative solutions and leading development teams
+            5+ years of building innovative solutions and leading development teams
           </p>
         </motion.div>
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from "react"
 import { motion } from "framer-motion"
 import { ChevronDown, Github, Linkedin, Mail, Phone, Download, Sparkles } from "lucide-react"
-import { totalExperinceCalculate } from "@/lib/utils"
 
 export default function Hero() {
   const scrollToSection = (sectionId: string) => {
@@ -109,7 +108,7 @@ export default function Hero() {
             transition={{ duration: 0.8, delay: 0.4 }}
             className="text-xl md:text-2xl text-slate-300 mb-6 font-medium"
           >
-            Fullstack Developer & AI Integration Specialist
+            Founder of Kodikas · Fullstack Developer & AI Integration Specialist
           </motion.p>
 
           <motion.p
@@ -118,7 +117,7 @@ export default function Hero() {
             transition={{ duration: 0.8, delay: 0.5 }}
             className="text-lg text-slate-400 mb-8 max-w-3xl mx-auto leading-relaxed"
           >
-            Crafting innovative digital solutions with {totalExperinceCalculate("full")} of expertise in React.js, Node.js, and AI integration.
+            Crafting innovative digital solutions with 5+ years of expertise in React.js, Node.js, and AI integration.
             Passionate about building scalable platforms that drive business growth and enhance user experiences.
           </motion.p>
 

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,11 +1,58 @@
 "use client"
 
 import { motion } from "framer-motion"
-import { ExternalLink, Github, Play, TrendingUp, Shield, Zap, Star } from "lucide-react"
+import { ExternalLink, Play, TrendingUp, Shield, Zap, Star } from "lucide-react"
 
 
 export default function Projects() {
   const projects = [
+    {
+      title: "Kodikas Partner — three-portal e-commerce SaaS",
+      description:
+        "A multi-tenant e-commerce platform built solo end to end: a customer storefront, a merchant portal with sales analytics, and a super-admin console with oversight of all stores.",
+      image: "/ecommerce-multi-portal-dashboard.png",
+      video: "/ecommerce-order-management-demo.png",
+      technologies: ["React", "TypeScript", "Node.js", "Multi-tenant", "Analytics"],
+      achievements: [
+        "Architected and built three connected portals single-handedly",
+        "Customer storefront with full shopping and checkout flow",
+        "Merchant portal with real-time sales analytics",
+        "Super-admin console with oversight across all stores",
+      ],
+      metrics: {
+        portals: "3",
+        tenancy: "Multi",
+        built: "Solo",
+      },
+      features: ["Customer Storefront", "Merchant Analytics", "Super-Admin Console", "Multi-tenant Architecture"],
+      color: "from-emerald-500 to-teal-500",
+      liveLinks: [
+        { label: "Storefront", url: "https://shop.kodikas.in" },
+        { label: "Partner Portal", url: "https://partner.kodikas.in" },
+      ],
+    },
+    {
+      title: "New Sarkari Result — Government Jobs Platform",
+      description:
+        "A live platform delivering government job notifications, results, and admit cards to job seekers across India, built for SEO and high-traffic content delivery.",
+      image: "/placeholder.svg",
+      video: "/placeholder.svg",
+      technologies: ["Next.js", "Node.js", "SEO", "SSR", "Content Delivery"],
+      achievements: [
+        "Launched a public government-jobs platform for Indian job seekers",
+        "Delivers job notifications, results, and admit cards",
+        "Engineered for SEO and high-traffic content delivery",
+        "Server-rendered with Next.js for fast, indexable pages",
+      ],
+      metrics: {
+        focus: "SEO",
+        traffic: "High",
+        region: "India",
+      },
+      features: ["Job Notifications", "Results & Admit Cards", "SEO Optimized", "High-Traffic Delivery"],
+      color: "from-teal-500 to-cyan-500",
+      liveLinks: [{ label: "Live Demo", url: "https://newsarkariresult.org" }],
+    },
     {
       title: "Logical Contracts Platform",
       description:
@@ -26,8 +73,7 @@ export default function Projects() {
       },
       features: ["AI-Powered Drafting", "Real-time Collaboration", "WebSockets", "Large Document Support"],
       color: "from-emerald-500 to-teal-500",
-      demoUrl: "#",
-      githubUrl: "#",
+      liveLinks: [] as { label: string; url: string }[],
     },
     {
       title: "SwilMart Multi-Portal System",
@@ -49,8 +95,7 @@ export default function Projects() {
       },
       features: ["Multi-tenant Support", "Real-time Tracking", "Inventory Management", "Payment Gateway"],
       color: "from-teal-500 to-cyan-500",
-      demoUrl: "#",
-      githubUrl: "#",
+      liveLinks: [] as { label: string; url: string }[],
     },
     {
       title: "Quickbit Crypto Platform",
@@ -72,8 +117,7 @@ export default function Projects() {
       },
       features: ["Crypto Payments", "Merchant Tools", "Security Compliance", "Transaction Tracking"],
       color: "from-cyan-500 to-blue-500",
-      demoUrl: "#",
-      githubUrl: "#",
+      liveLinks: [] as { label: string; url: string }[],
     },
     {
       title: "Swil ERP Admin System",
@@ -95,8 +139,7 @@ export default function Projects() {
       },
       features: ["Role Management", "Permission Control", "Advanced Validations", "Performance Optimization"],
       color: "from-orange-500 to-amber-500",
-      demoUrl: "#",
-      githubUrl: "#",
+      liveLinks: [] as { label: string; url: string }[],
     },
   ]
 
@@ -245,20 +288,22 @@ export default function Projects() {
                   </div>
 
                   {/* Action Buttons */}
-                  <div className="flex gap-4">
-                    <button
-                      className={`flex items-center px-4 py-2 rounded-md font-medium bg-gradient-to-r ${project.color} hover:scale-105 text-white shadow-lg transform transition-all duration-300`}
-                    >
-                      <ExternalLink className="mr-2 h-4 w-4" />
-                      Live Demo
-                    </button>
-                    <button
-                      className="flex items-center px-4 py-2 rounded-md font-medium border-2 border-emerald-500/50 text-emerald-400 hover:bg-emerald-500 hover:text-white bg-transparent transition-all duration-300"
-                    >
-                      <Github className="mr-2 h-4 w-4" />
-                      View Code
-                    </button>
-                  </div>
+                  {project.liveLinks.length > 0 && (
+                    <div className="flex gap-4 flex-wrap">
+                      {project.liveLinks.map((link, linkIndex) => (
+                        <a
+                          key={linkIndex}
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={`flex items-center px-4 py-2 rounded-md font-medium bg-gradient-to-r ${project.color} hover:scale-105 text-white shadow-lg transform transition-all duration-300`}
+                        >
+                          <ExternalLink className="mr-2 h-4 w-4" />
+                          {link.label}
+                        </a>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
## What changed

**Experience**
- Added **Founder & Full-Stack Developer at Kodikas** (2026–Present, Remote · India) as the most recent timeline entry, with achievements and notable projects (Kodikas Partner, Kodikas Studio, New Sarkari Result).

**Hero**
- Added "Founder of Kodikas" to the title line.
- Made the years-of-experience number consistent at **5+** (replaced the dynamic calculator usage).
- Removed the "100K+ Users Impacted" stat from the About section.

**Projects**
- Added featured card **Kodikas Partner — three-portal e-commerce SaaS** (React, TypeScript, Node.js) with working Live Demo links to https://shop.kodikas.in and https://partner.kodikas.in.
- Added featured card **New Sarkari Result — Government Jobs Platform** (Next.js, Node.js) with a working Live Demo link to https://newsarkariresult.org.
- Live Demo buttons now render only for projects with real URLs. This removes the dead "Live Demo" / "View Code" buttons from employer-owned projects (Quickbit, Logical Contracts, SwilMart, and Swil ERP Admin).

**Other**
- Confirmed the LinkedIn link is `https://www.linkedin.com/in/iamomeshkumarr/` everywhere (already correct).
- Removed now-unused imports (`totalExperinceCalculate`, `Github`).

## Reviewer notes
- **Swil ERP Admin** was not explicitly named for button removal, but it was also employer-owned with dead `#` links, so under the new "render only real links" logic its buttons are gone too.
- The **New Sarkari Result** card uses `/placeholder.svg` since no screenshot exists in `/public` yet — swap in a real image when available.
- Pre-existing type errors in `hooks/use-toast.ts` are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
